### PR TITLE
Fix snippet string representation method

### DIFF
--- a/Python/Django/djangosnippets/snippets/models.py
+++ b/Python/Django/djangosnippets/snippets/models.py
@@ -10,7 +10,7 @@ class Snippet(models.Model):
     created_at = models.DateTimeField("投稿日",auto_now_add=True)
     updated_at = models.DateTimeField("更新日",auto_now = True)
 
-    def __self__(self):
+    def __str__(self):
         return self.title
     
 


### PR DESCRIPTION
## Summary
- update Django Snippet model to use `__str__` instead of the nonstandard `__self__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6842c72e6c24833094916049f352762c